### PR TITLE
fix: 正确提取微博热搜热度值

### DIFF
--- a/src/modules/weibo.module.ts
+++ b/src/modules/weibo.module.ts
@@ -47,7 +47,9 @@ class ServiceWeibo {
     return (((data?.cards?.[0]?.card_group || []) as Item[]).filter((e) => !e.pic.includes('stick')) || []).map(
       (e) => ({
         title: e.desc,
-        hot_value: 0,
+        hot_value: typeof e.desc_extr === 'number'
+          ? e.desc_extr
+          : parseInt(String(e.desc_extr).replace(/\D/g, '')) || 0,
         link: `https://s.weibo.com/weibo?q=${encodeURIComponent(e.desc)}`,
       }),
     )


### PR DESCRIPTION
## Summary

- 修复微博热搜 `hot_value` 始终为 0 的问题
- 微博 API 的 `desc_extr` 字段实际返回了热度数据，但之前代码硬编码为 0 未使用
- 支持纯数字（如 `760970`）和带标签字符串（如 `"综艺 1050401"` → `1050401`）两种格式的解析

## 问题复现

访问 https://60s.viki.moe/v2/weibo 可以看到所有条目的 `hot_value` 均为 `0`。

## 修复方式

将 `hot_value: 0` 替换为从 `desc_extr` 字段提取实际热度值的逻辑：

```typescript
hot_value: typeof e.desc_extr === 'number'
  ? e.desc_extr
  : parseInt(String(e.desc_extr).replace(/\D/g, '')) || 0,
```